### PR TITLE
Replace undefined constant ROOTDIR

### DIFF
--- a/src/WebfleetOptions.php
+++ b/src/WebfleetOptions.php
@@ -34,7 +34,7 @@ class WebfleetOptions{
 	/**
 	 * @var string
 	 */
-	public $cacert = ROOTDIR.'storage'.DIRECTORY_SEPARATOR.'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
+	public $cacert = $storageDir.DIRECTORY_SEPARATOR.'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
 
 
 	/**


### PR DESCRIPTION
The ROOTDIR constant is never defined and you have to create the WebfleetOptions object in order to create WebfleetConnect.
So if you absolutely have to set a default value for the cacert.pem, make use of the $storageDir variable instead of the ROOTDIR constant