### PR TITLE
Urlencode env variables in Auth options

### DIFF
--- a/src/EndpointHandler.php
+++ b/src/EndpointHandler.php
@@ -128,7 +128,7 @@ class EndpointHandler{
 		}
 
 		$requestOptions = new RequestOptions;
-		$requestOptions->ca_info = __DIR__.'/../storage/cert/cacert.pem';
+		$requestOptions->ca_info = $this->webfleetOptions->cacert;
 
 		$request = new Request($requestOptions);
 

--- a/src/WebfleetConnect.php
+++ b/src/WebfleetConnect.php
@@ -243,10 +243,10 @@ class WebfleetConnect{
 
 		if(!$authenticationParams){
 			$authenticationParams           = new Authentication;
-			$authenticationParams->account  = getenv('WEBFLEET_ACCOUNT');
-			$authenticationParams->username = getenv('WEBFLEET_USERNAME');
-			$authenticationParams->password = getenv('WEBFLEET_PASSWORD');
-			$authenticationParams->apikey   = getenv('WEBFLEET_APIKEY');
+			$authenticationParams->account  = urlencode(getenv('WEBFLEET_ACCOUNT'));
+			$authenticationParams->username = urlencode(getenv('WEBFLEET_USERNAME'));
+			$authenticationParams->password = urlencode(getenv('WEBFLEET_PASSWORD'));
+			$authenticationParams->apikey   = urlencode(getenv('WEBFLEET_APIKEY'));
 		}
 
 		$this->authenticationParams = $authenticationParams;

--- a/src/WebfleetOptions.php
+++ b/src/WebfleetOptions.php
@@ -34,7 +34,7 @@ class WebfleetOptions{
 	/**
 	 * @var string
 	 */
-	public $cacert = $storageDir.DIRECTORY_SEPARATOR.'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
+	public $cacert = 'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
 
 
 	/**

--- a/src/WebfleetOptions.php
+++ b/src/WebfleetOptions.php
@@ -34,7 +34,7 @@ class WebfleetOptions{
 	/**
 	 * @var string
 	 */
-	public $cacert = ROOTDIR.'storage'.DIRECTORY_SEPARATOR.'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
+	public $cacert = $storageDir.DIRECTORY_SEPARATOR.'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
 
 
 	/**


### PR DESCRIPTION
Not sure if you need that at all.
Even though this lists 3 commits, the other 2 are from the patch-1 branch about the ROOTDIR thing.

What it does is urlencode the authentication params from the env file before submitting. This is needed for me because I have both special characters in the customer name and in the user password.

Don't worry about replying here. I hope you don't mind me submitting additional pull requests even though you don't have time to consider them at the moment.
I'll continue with my own fork, but I'll be glad to share any improvements back to your repo.