### PR TITLE
Various Certificate related fixes

### DIFF
--- a/src/EndpointHandler.php
+++ b/src/EndpointHandler.php
@@ -128,7 +128,7 @@ class EndpointHandler{
 		}
 
 		$requestOptions = new RequestOptions;
-		$requestOptions->ca_info = __DIR__.'/../storage/cert/cacert.pem';
+		$requestOptions->ca_info = $this->webfleetOptions->cacert;
 
 		$request = new Request($requestOptions);
 

--- a/src/WebfleetConnect.php
+++ b/src/WebfleetConnect.php
@@ -243,10 +243,10 @@ class WebfleetConnect{
 
 		if(!$authenticationParams){
 			$authenticationParams           = new Authentication;
-			$authenticationParams->account  = getenv('WEBFLEET_ACCOUNT');
-			$authenticationParams->username = getenv('WEBFLEET_USERNAME');
-			$authenticationParams->password = getenv('WEBFLEET_PASSWORD');
-			$authenticationParams->apikey   = getenv('WEBFLEET_APIKEY');
+			$authenticationParams->account  = urlencode(getenv('WEBFLEET_ACCOUNT'));
+			$authenticationParams->username = urlencode(getenv('WEBFLEET_USERNAME'));
+			$authenticationParams->password = urlencode(getenv('WEBFLEET_PASSWORD'));
+			$authenticationParams->apikey   = urlencode(getenv('WEBFLEET_APIKEY'));
 		}
 
 		$this->authenticationParams = $authenticationParams;

--- a/src/WebfleetOptions.php
+++ b/src/WebfleetOptions.php
@@ -34,7 +34,7 @@ class WebfleetOptions{
 	/**
 	 * @var string
 	 */
-	public $cacert = $storageDir.DIRECTORY_SEPARATOR.'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
+	public $cacert = 'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
 
 
 	/**

--- a/src/WebfleetOptions.php
+++ b/src/WebfleetOptions.php
@@ -34,7 +34,7 @@ class WebfleetOptions{
 	/**
 	 * @var string
 	 */
-	public $cacert = ROOTDIR.'storage'.DIRECTORY_SEPARATOR.'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
+	public $cacert = $storageDir.DIRECTORY_SEPARATOR.'cert'.DIRECTORY_SEPARATOR.'cacert.pem';
 
 
 	/**


### PR DESCRIPTION
1. ROOTDIR in WebFleetOptions is never defined throughout the project.
2. Env variables have to be URL encoded in order to successfully authenticate with WebFleet.
3. You defined a useless variable to set the path for the root certificate / ca cert and instead relied on the CA certificate being placed in a specific (undocumented) folder. Use the variable to find the right CA certificate instead.